### PR TITLE
Implemented heap allocation optimization via mempool, reserve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/build
 **/docs
 **/lib
+**/heaptrack*
 *.NASDAQ_ITCH50
 
 **/.vscode/

--- a/buildit.sh
+++ b/buildit.sh
@@ -1,4 +1,4 @@
 rm -rf build
-cmake -S ./src -B build -DCMAKE_BUILD_TYPE=Debug
+cmake -S ./src -B build -DCMAKE_BUILD_TYPE=Release
 cd build
 make

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ include_directories(
     "./bookkeeping" 
     "./messages"
     "./utils"
+    "./data_structures"
     ${Boost_INCLUDE_DIRS}
 )
 
@@ -29,6 +30,7 @@ file(GLOB SOURCES
   "./bookkeeping/*.cpp"
   "./messages/*.cpp"
   "./utils/*.cpp"
+  "./data_structures/*.cpp"
 )
 
 # The compiled library code is here

--- a/src/bookkeeping/OrderBook.cpp
+++ b/src/bookkeeping/OrderBook.cpp
@@ -17,7 +17,6 @@ OrderBook& OrderBook::getInstance() {
 
 /**
  * Add the active order data to the book.
- * Struct initialized with "malloc" so it can be freed later
  * This should never be called more than once for a give orderReferenceNumber
  */
 void OrderBook::addToActiveOrders(uint64_t orderReferenceNumber, uint16_t stockLocate, uint32_t numShares, uint32_t price) {

--- a/src/bookkeeping/OrderBook.h
+++ b/src/bookkeeping/OrderBook.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <unordered_map>
 
+constexpr uint32_t BYTE_PER_MB = 1048576;
+
 /**
  * Book has two mappings:
  * 1. Order Reference Number -> ActiveOrderData
@@ -21,9 +23,9 @@ struct ExecutedOrderOrTradeData {
 class ActiveOrderData {
 
     private: 
-        uint16_t stockLocate;
         uint32_t numShares;
         uint32_t price;
+        uint16_t stockLocate;
 
     public:
 
@@ -54,6 +56,11 @@ class OrderBook {
     public:
 
         static OrderBook& getInstance();
+
+        // Reserve 64 MB of memory for this map
+        OrderBook() {
+            _activeOrdersBook.reserve((BYTE_PER_MB * 64) / sizeof(ActiveOrderData));
+        }
 
         // Functions for maintaining the book
         void addToActiveOrders(uint64_t orderReferenceNumber, uint16_t stockLocate, uint32_t numShares, uint32_t price);

--- a/src/data_structures/mempool.h
+++ b/src/data_structures/mempool.h
@@ -1,0 +1,73 @@
+#ifndef NASDAQ_DATA_STRUCTURES_MEMPOOL_H_
+#define NASDAQ_DATA_STRUCTURES_MEMPOOL_H_
+
+#include <cmath>
+#include <cassert>
+#include <atomic>
+
+#include <queue_utils.h>
+
+/**
+ * Memory Pool for static allocation of frequently produced messages in the SPSC model.
+ * To avoid needing mutex locks, hold invariant that MempoolSize must not exceed the size of the queue.
+ * See https://rigtorp.se/ringbuffer/ for lockfree ring buffer implementation reference.
+ */
+template <typename T, const size_t MempoolSize>
+class MempoolSPSC {
+
+    /**
+     * Whole point of the SPSC mempool is to NEVER return a nullptr when requesting a resource.
+     * It is possible that:
+     * 1. The entire SPSC queue may be full of a single message instance (empty mempool).
+     * 2. The consumer may pop an instance off of the queue for processing (empty mempool, but queue is ready for writes).
+     * 3. The producer requests another instance of the same message type to add to the queue BEFORE THE CONSUMER INVOKES DELETE, returning the resource to the mempool.
+     * Thus, we must account for the fact that there may be as many as SPSC_QUEUE_CAPACITY + 1 messages of a single instance in existance at any given point. 
+     */
+    static_assert(MempoolSize > SPSC_QUEUE_CAPACITY + 1);
+
+    private:
+        alignas(T) std::byte buffer[sizeof(T) * MempoolSize];
+        T* isFreeBufferMap[MempoolSize];
+
+        // On AMD64/x86_64 and ARM CPUs, cache lines are 64 bytes
+        alignas(64) std::atomic<size_t> _allocatorIndex{0};
+        alignas(64) std::atomic<size_t> _deallocatorIndex{0};
+
+    public:
+        MempoolSPSC() {
+            for(size_t i = 0; i < MempoolSize; i++)
+                isFreeBufferMap[i] = reinterpret_cast<T*>(buffer + (i * sizeof(T)));
+        }
+
+        /**
+         * Return a pointer to a readily available resource
+         */
+        T* allocate() {
+            auto const allocatorIndex = _allocatorIndex.load(std::memory_order_relaxed);
+            auto nextAllocatorIndex = allocatorIndex + 1;
+            if(nextAllocatorIndex == MempoolSize) 
+                nextAllocatorIndex = 0;
+            if(nextAllocatorIndex == _deallocatorIndex.load(std::memory_order_acquire))
+                return nullptr;
+            T* resource = isFreeBufferMap[allocatorIndex];
+            _allocatorIndex.store(nextAllocatorIndex, std::memory_order_release);
+            return resource;
+        }
+
+        /**
+         * Take an allocated resource and return it to the memory pool
+         */
+        void deallocate(T* item) {
+            auto const deallocatorIndex = _deallocatorIndex.load(std::memory_order_relaxed);
+            if(deallocatorIndex == _allocatorIndex.load(std::memory_order_acquire))
+                return;
+            isFreeBufferMap[deallocatorIndex] = item;
+            auto nextDeallocatorIndex = deallocatorIndex + 1;
+            if(nextDeallocatorIndex == MempoolSize)
+                nextDeallocatorIndex = 0;
+            _deallocatorIndex.store(nextDeallocatorIndex, std::memory_order_release);
+        }
+
+};
+
+#endif // NASDAQ_DATA_STRUCTURES_MEMPOOL_H_

--- a/src/messages/AddOrder.cpp
+++ b/src/messages/AddOrder.cpp
@@ -4,6 +4,8 @@
 #include <string_utils.h>
 #include <endian_utils.h>
 
+MempoolSPSC<AddOrder, SPSC_QUEUE_CAPACITY + 2> AddOrder::_mempool;
+
 /** 
  * Parse the AddOrder message body
  */
@@ -19,5 +21,5 @@ AddOrder* parseAddOrderBody(BinaryMessageHeader header, const char* data) {
     stripWhitespaceFromCPPString(stock);
     offset += STOCK_SIZE;
     uint32_t price = toHostEndianUpTo64(&data[offset], 4); // We know this is a 4 byte int
-    return new AddOrder(std::move(header), orderReferenceNumber, buySellIndicator, shares, stock, price);
+    return new AddOrder(std::move(header), orderReferenceNumber, buySellIndicator, shares, std::move(stock), price);
 }

--- a/src/messages/AddOrderMPID.cpp
+++ b/src/messages/AddOrderMPID.cpp
@@ -7,6 +7,8 @@
 #include <string_utils.h>
 #include <endian_utils.h>
 
+MempoolSPSC<AddOrderMPID, SPSC_QUEUE_CAPACITY + 2> AddOrderMPID::_mempool;
+
 /** 
  * Parse the AddOrderMPID message body
  */

--- a/src/messages/BrokenTradeOrOrderExecution.cpp
+++ b/src/messages/BrokenTradeOrOrderExecution.cpp
@@ -2,6 +2,8 @@
 
 #include <endian_utils.h>
 
+MempoolSPSC<BrokenTradeOrOrderExecution, SPSC_QUEUE_CAPACITY + 2> BrokenTradeOrOrderExecution::_mempool;
+
 /**
  * Parse the BrokenTradeOrOrderExecution body
  */

--- a/src/messages/BrokenTradeOrOrderExecution.h
+++ b/src/messages/BrokenTradeOrOrderExecution.h
@@ -7,15 +7,31 @@
 
 #include <VWAPManager.h>
 
+#include <mempool.h>
+
 // Class to store the Broken Trade or Order Execution message body
 class BrokenTradeOrOrderExecution : public Message {
     private:
         uint64_t matchNumber;
+        static MempoolSPSC<BrokenTradeOrOrderExecution, SPSC_QUEUE_CAPACITY + 2> _mempool;
     public:
         BrokenTradeOrOrderExecution(BinaryMessageHeader header, uint64_t matchNumber) :
         Message(std::move(header)),
         matchNumber(matchNumber)
         {}
+
+        /**
+         * Overload new/delete to use the mempool, rather than heap allocations
+         */
+        void* operator new(size_t) {
+            void* ptr = _mempool.allocate();
+            if (ptr == nullptr) throw std::bad_alloc();
+            return ptr;
+        }
+
+        void operator delete(void* ptr) {
+            _mempool.deallocate(static_cast<BrokenTradeOrOrderExecution*>(ptr));
+        }
 
         bool processMessage() const override { VWAPManager::getInstance().handleBrokenTrade(header.getStockLocate(), matchNumber); return true; }
 

--- a/src/messages/CrossTrade.cpp
+++ b/src/messages/CrossTrade.cpp
@@ -4,6 +4,8 @@
 #include <string_utils.h>
 #include <endian_utils.h>
 
+MempoolSPSC<CrossTrade, SPSC_QUEUE_CAPACITY + 2> CrossTrade::_mempool;
+
 /**
  * Parse the cross trade body from the binary buffer
  */

--- a/src/messages/Message.h
+++ b/src/messages/Message.h
@@ -18,10 +18,12 @@ class Message {
         explicit Message(BinaryMessageHeader header) : 
         header(std::move(header))
         {}
+        explicit Message() = default;
         virtual ~Message() = default;
         virtual bool processMessage() const = 0; 
 
         const BinaryMessageHeader& getHeader() const { return header; }
+        void setHeader(BinaryMessageHeader header) { this -> header = std::move(header); }
 };
 
 #endif // NASDAQ_MESSAGE_H_

--- a/src/messages/MessageHeader.h
+++ b/src/messages/MessageHeader.h
@@ -22,6 +22,11 @@ class BinaryMessageHeader {
         stockLocate(stockLocate),
         timestamp(timestamp)
         {}
+        BinaryMessageHeader() :
+        messageType('0'),
+        stockLocate(0),
+        timestamp(0)
+        {}
         ~BinaryMessageHeader() = default;
         BinaryMessageHeader(const BinaryMessageHeader&) = default;
         BinaryMessageHeader& operator=(const BinaryMessageHeader&) = default;

--- a/src/messages/OrderCancel.cpp
+++ b/src/messages/OrderCancel.cpp
@@ -2,6 +2,8 @@
 
 #include <endian_utils.h>
 
+MempoolSPSC<OrderCancel, SPSC_QUEUE_CAPACITY + 2> OrderCancel::_mempool;
+
 /**
  * Parse the OrderCancel body
  */

--- a/src/messages/OrderDelete.cpp
+++ b/src/messages/OrderDelete.cpp
@@ -2,6 +2,8 @@
 
 #include <endian_utils.h>
 
+MempoolSPSC<OrderDelete, SPSC_QUEUE_CAPACITY + 2> OrderDelete::_mempool;
+
 /**
  * Parse the OrderDelete body
  */

--- a/src/messages/OrderDelete.h
+++ b/src/messages/OrderDelete.h
@@ -6,18 +6,32 @@
 #include <Message.h>
 
 #include <OrderBook.h>
+#include <mempool.h>
+#include <queue_utils.h>
 
 // Class to store the Order Delete message body
 class OrderDelete : public Message {
 
     private: 
         uint64_t orderReferenceNumber;
+
+        static MempoolSPSC<OrderDelete, SPSC_QUEUE_CAPACITY + 2> _mempool;
     
     public:
         OrderDelete(BinaryMessageHeader header, uint64_t orderReferenceNumber) :
         Message(std::move(header)),
         orderReferenceNumber(orderReferenceNumber)
         {}
+
+        void* operator new(size_t) {
+            void* ptr = _mempool.allocate();
+            if (ptr == nullptr) throw std::bad_alloc();
+            return ptr;
+        }
+
+        void operator delete(void* ptr) {
+            _mempool.deallocate(static_cast<OrderDelete*>(ptr));
+        }
 
         bool processMessage() const override { OrderBook::getInstance().deleteActiveOrder(orderReferenceNumber); return true; }
 

--- a/src/messages/OrderExecuted.cpp
+++ b/src/messages/OrderExecuted.cpp
@@ -2,6 +2,8 @@
 
 #include <endian_utils.h>
 
+MempoolSPSC<OrderExecuted, SPSC_QUEUE_CAPACITY + 2> OrderExecuted::_mempool;
+
 OrderExecuted* parseOrderExecutedBody(BinaryMessageHeader header, const char* data) {
     size_t offset = 0;
     uint64_t orderReferenceNumber = toHostEndianUpTo64(&data[offset], 8); // We know this is 8 bytes

--- a/src/messages/OrderExecuted.h
+++ b/src/messages/OrderExecuted.h
@@ -8,6 +8,8 @@
 #include <time_utils.h>
 #include <VWAPManager.h>
 
+#include <mempool.h>
+
 // Store all other fields for the OrderExecuted message here
 class OrderExecuted : public Message {
 
@@ -16,6 +18,8 @@ class OrderExecuted : public Message {
         uint32_t executedShares;
         uint64_t matchNumber;
 
+        static MempoolSPSC<OrderExecuted, SPSC_QUEUE_CAPACITY + 2> _mempool;
+
     public:
         OrderExecuted(BinaryMessageHeader header, uint64_t orderReferenceNumber, uint32_t executedShares, uint64_t matchNumber) :
         Message(std::move(header)),
@@ -23,6 +27,19 @@ class OrderExecuted : public Message {
         executedShares(executedShares),
         matchNumber(matchNumber)
         {}
+
+        /**
+         * Overload new/delete to use the mempool, rather than heap allocations
+         */
+        void* operator new(size_t) {
+            void* ptr = _mempool.allocate();
+            if (ptr == nullptr) throw std::bad_alloc();
+            return ptr;
+        }
+
+        void operator delete(void* ptr) {
+            _mempool.deallocate(static_cast<OrderExecuted*>(ptr));
+        }
 
         bool processMessage() const override { 
             if(isAfterHours(header.getTimestamp())) return false;

--- a/src/messages/OrderExecutedWithPrice.cpp
+++ b/src/messages/OrderExecutedWithPrice.cpp
@@ -4,6 +4,8 @@
 
 #include <endian_utils.h>
 
+MempoolSPSC<OrderExecutedWithPrice, SPSC_QUEUE_CAPACITY + 2> OrderExecutedWithPrice::_mempool;
+
 /**
  * Parse the orderExecutedWithPrice message body
  */

--- a/src/messages/OrderReplace.cpp
+++ b/src/messages/OrderReplace.cpp
@@ -2,6 +2,8 @@
 
 #include <endian_utils.h>
 
+MempoolSPSC<OrderReplace, SPSC_QUEUE_CAPACITY + 2> OrderReplace::_mempool;
+
 /**
  * Parse the OrderReplace body
  */

--- a/src/messages/StockTradingAction.cpp
+++ b/src/messages/StockTradingAction.cpp
@@ -4,6 +4,8 @@
 
 #include <string_utils.h>
 
+MempoolSPSC<StockTradingAction, SPSC_QUEUE_CAPACITY + 2> StockTradingAction::_mempool;
+
 /**
  * Parse the stock trading action body contents from the buffer
  */

--- a/src/messages/TradeNonCross.cpp
+++ b/src/messages/TradeNonCross.cpp
@@ -5,6 +5,8 @@
 #include <endian_utils.h>
 #include <string_utils.h>
 
+MempoolSPSC<TradeNonCross, SPSC_QUEUE_CAPACITY + 2> TradeNonCross::_mempool;
+
 /**
  * Parse the Trade Non-Cross body from the binary message
  */

--- a/src/utils/queue_utils.h
+++ b/src/utils/queue_utils.h
@@ -7,10 +7,15 @@
 
 #include <boost/lockfree/spsc_queue.hpp>
 
+// Important to define, since this will the maximum memory pool size for high freq message pools in SPSC implementation
+constexpr uint8_t SPSC_QUEUE_CAPACITY = 32;
+
 /**
  * A little wrapper for the boost lockfree SPSC queue
  */
 class LockfreeSPSC {
+
+    friend class AddOrder;
 
     public:
         static LockfreeSPSC& getInstance();
@@ -22,7 +27,7 @@ class LockfreeSPSC {
 
     private:
         static LockfreeSPSC* _instance;
-        boost::lockfree::spsc_queue<Message*, boost::lockfree::capacity<32>> mq;
+        boost::lockfree::spsc_queue<Message*, boost::lockfree::capacity<SPSC_QUEUE_CAPACITY>> mq;
 };
 
 #endif // NASDAQ_UTILS_QUEUE_UTILS_H_


### PR DESCRIPTION
This commit does 2 main optimizations:
1. Implement a static memory pool per-ITCH message to avoid ((364470757 * 2)) heap allocations !!!!!!
This optimization has very clearly had a positive impact. See the two heaptrack outputs below:

Before Memory Pool:
![memtrack_baseline](https://github.com/user-attachments/assets/a9ec2af8-db6c-4636-a932-1cc40deea2a6)



After Memory Pool:
![heaptrack_mempool_migration](https://github.com/user-attachments/assets/0e41830f-cf1a-4464-8340-0dfe9b55314e)

2. Reserve 64 MB worth of space in the OrderBook to avoid excessive rehashing. I noticed a performance improvement after making this change, but the heaptrack output does not show a decrease in rehashes. This will require further investigation.   